### PR TITLE
Add pyhdbpp as requirement

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 4253b307afcbd6b2edd96f773a765a0c6156bf29305c1e25f9800e86cabeae9b
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,6 +26,7 @@ requirements:
     - pyqtgraph >=0.11
     - python >={{ python_min }}
     - taurus >=4.5.2
+    - pyhdbpp
 
 test:
   imports:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [X] Ensured the license file is being packaged.

Hi @beenje , I added pyhdbpp as a dependency as it is needed to add archiving support in taurus_pyqtgraph. For pip it is considered as an extras_require (archiving) but in case of conda I would add it as default. Is it ok?

Maybe we could take the opportunity to also remove cpascual as mantainer and add me instead.

Thanks!
